### PR TITLE
fix: use var instead of const

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const botlist = require('./data/bots')
-const botRegExp = new RegExp('(' + botlist.join('|') + ')', 'ig')
+var botlist = require('./data/bots')
+var botRegExp = new RegExp('(' + botlist.join('|') + ')', 'ig')
 
 module.exports = function isBot(ua) {
   return !!(ua||'').match(botRegExp)


### PR DESCRIPTION
so, It can use in the browser with webpack.

In principle, If a package wants to work in browser and Node. **DO WRITE AND ES6 WITHOUT TRANSFORM IT**

The transformer like ``babel`` are always ignore npm module.